### PR TITLE
Add a library for mapping user agents to browser capabilities.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   },
   "dependencies": {
     "@types/express": "^4.0.35",
-    "express": "^4.15.2"
+    "@types/ua-parser-js": "^0.7.30",
+    "express": "^4.15.2",
+    "ua-parser-js": "^0.7.12"
   }
 }

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {UAParser} from 'ua-parser-js';
+
+/**
+ * A browser feature.
+ */
+export type Capability =
+    // ECMAScript 2015 (aka ES6).
+    'es2015' |
+    // HTTP/2 Server Push.
+    'push';
+
+/**
+ * Return a capability map for the given user agent string.
+ */
+export function capabilities(userAgent: string):
+    {[key in Capability]: boolean} {
+  const ua = new UAParser(userAgent);
+  const supports = browserCapabilities[ua.getBrowser().name];
+  return {
+    es2015: !!supports && supports.es2015(ua),
+    push: !!supports && supports.push(ua),
+  };
+};
+
+/**
+ * Parse a "x.y.z" version string of any length into integer parts. Returns -1
+ * for a part that doesn't parse.
+ */
+export function parseVersion(version: string): number[] {
+  return version.split('.').map((part) => {
+    const i = parseInt(part, 10);
+    return isNaN(i) ? -1 : i;
+  });
+}
+
+/**
+ * Return whether `version` is at least as high as `requirement`.
+ */
+export function satisfies(requirement: number[], version: number[]): boolean {
+  for (let i = 0; i < requirement.length; i++) {
+    const r = requirement[i];
+    const v = version.length > i ? version[i] : 0;
+    if (v > r) {
+      return true;
+    }
+    if (v < r) {
+      return false;
+    }
+  }
+  return true;
+}
+
+type CapabilityPredicate = (ua: UAParser) => boolean;
+
+/**
+ * Make a predicate that checks if the browser version is at least this high.
+ */
+function since(...requirement: number[]): CapabilityPredicate {
+  return (ua) => satisfies(requirement, parseVersion(ua.getBrowser().version));
+}
+
+const browserCapabilities:
+    {[browser: string]: {[key in Capability]: CapabilityPredicate}} = {
+      'Chrome': {
+        es2015: since(49),
+        push: since(41),
+      },
+      'Chromium': {
+        es2015: since(49),
+        push: since(41),
+      },
+      'OPR': {
+        es2015: since(36),
+        push: since(28),
+      },
+      'Vivaldi': {
+        es2015: since(1),
+        push: () => false,  // TODO Test if Vivaldi supports push.
+      },
+      'Mobile Safari': {
+        es2015: since(10),
+        push: since(9, 2),
+      },
+      'Safari': {
+        es2015: since(10),
+        push: (ua) => {
+          return satisfies([9], parseVersion(ua.getBrowser().version)) &&
+              // HTTP/2 on desktop Safari requires macOS 10.11 according to
+              // caniuse.com.
+              satisfies([10, 11], parseVersion(ua.getOS().version));
+        },
+      },
+      'Edge': {
+        // Edge versions before 15.15063 may contain a JIT bug affecting ES6
+        // constructors (https://github.com/Microsoft/ChakraCore/issues/1496).
+        es2015: since(15, 15063),
+        push: since(12),
+      },
+      'Firefox': {
+        es2015: since(51),
+        push: since(36),
+      },
+    };

--- a/src/test/capabilities_test.ts
+++ b/src/test/capabilities_test.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+import * as capabilities from '../capabilities';
+
+function assertCapabilities(
+    userAgent: string, expect: {[key in capabilities.Capability]: boolean}) {
+  assert.deepEqual(capabilities.capabilities(userAgent), expect);
+}
+
+suite('capabilities', function() {
+  test('unknown browser has no capabilities', () => {
+    assertCapabilities('unknown browser', {es2015: false, push: false});
+  });
+
+  test('chrome has all the capabilities', () => {
+    assertCapabilities(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.96 Safari/537.36',
+        {es2015: true, push: true});
+  });
+
+  test('edge es2015 support is predicated on minor browser version', () => {
+    assertCapabilities(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.14986',
+        {es2015: false, push: true});
+    assertCapabilities(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063',
+        {es2015: true, push: true});
+  });
+
+  test('safari push capability is predicated on macOS version', () => {
+    assertCapabilities(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.1 Safari/603.1.30',
+        {es2015: true, push: false});
+    assertCapabilities(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.1 Safari/603.1.30',
+        {es2015: true, push: true});
+  });
+
+  test('parseVersion parses with fallback to -1', () => {
+    assert.deepEqual(capabilities.parseVersion('37'), [37]);
+    assert.deepEqual(capabilities.parseVersion('10.987.00.1'), [10, 987, 0, 1]);
+    assert.deepEqual(capabilities.parseVersion('4..foo.7'), [4, -1, -1, 7]);
+  });
+
+  test('satisfies checks all required parts', () => {
+    assert.isTrue(capabilities.satisfies([3, 2, 1], [3, 2, 1]));
+    assert.isTrue(capabilities.satisfies([3, 2, 1], [3, 2, 1, 4]));
+    assert.isTrue(capabilities.satisfies([3, 2, 1], [4, 1, 0]));
+    assert.isTrue(capabilities.satisfies([3, 2, 0], [3, 2]));
+    assert.isFalse(capabilities.satisfies([3, 2, 1], [2, 2, 1]));
+    assert.isFalse(capabilities.satisfies([3, 2, 1], [3, 1, 1]));
+    assert.isFalse(capabilities.satisfies([3, 2, 1], [3, 1, 0]));
+    assert.isFalse(capabilities.satisfies([3, 2, 1], [3, 2]));
+    assert.isFalse(capabilities.satisfies([3, 2, 1], [3, 2]));
+    assert.isFalse(capabilities.satisfies([3, 2, 1], []));
+  });
+});

--- a/src/test/capabilities_test.ts
+++ b/src/test/capabilities_test.ts
@@ -15,38 +15,39 @@
 import {assert} from 'chai';
 import * as capabilities from '../capabilities';
 
-function assertCapabilities(
-    userAgent: string, expect: {[key in capabilities.Capability]: boolean}) {
-  assert.deepEqual(capabilities.capabilities(userAgent), expect);
+function assertBrowserCapabilities(
+    userAgent: string, expect: capabilities.BrowserCapability[]) {
+  assert.deepEqual(
+      capabilities.browserCapabilities(userAgent), new Set(expect));
 }
 
 suite('capabilities', function() {
   test('unknown browser has no capabilities', () => {
-    assertCapabilities('unknown browser', {es2015: false, push: false});
+    assertBrowserCapabilities('unknown browser', []);
   });
 
   test('chrome has all the capabilities', () => {
-    assertCapabilities(
+    assertBrowserCapabilities(
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.96 Safari/537.36',
-        {es2015: true, push: true});
+        ['es2015', 'push']);
   });
 
   test('edge es2015 support is predicated on minor browser version', () => {
-    assertCapabilities(
+    assertBrowserCapabilities(
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.14986',
-        {es2015: false, push: true});
-    assertCapabilities(
+        ['push']);
+    assertBrowserCapabilities(
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063',
-        {es2015: true, push: true});
+        ['es2015', 'push']);
   });
 
   test('safari push capability is predicated on macOS version', () => {
-    assertCapabilities(
+    assertBrowserCapabilities(
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.1 Safari/603.1.30',
-        {es2015: true, push: false});
-    assertCapabilities(
+        ['push']);
+    assertBrowserCapabilities(
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.1 Safari/603.1.30',
-        {es2015: true, push: true});
+        ['push']);
   });
 
   test('parseVersion parses with fallback to -1', () => {
@@ -55,16 +56,16 @@ suite('capabilities', function() {
     assert.deepEqual(capabilities.parseVersion('4..foo.7'), [4, -1, -1, 7]);
   });
 
-  test('satisfies checks all required parts', () => {
-    assert.isTrue(capabilities.satisfies([3, 2, 1], [3, 2, 1]));
-    assert.isTrue(capabilities.satisfies([3, 2, 1], [3, 2, 1, 4]));
-    assert.isTrue(capabilities.satisfies([3, 2, 1], [4, 1, 0]));
-    assert.isTrue(capabilities.satisfies([3, 2, 0], [3, 2]));
-    assert.isFalse(capabilities.satisfies([3, 2, 1], [2, 2, 1]));
-    assert.isFalse(capabilities.satisfies([3, 2, 1], [3, 1, 1]));
-    assert.isFalse(capabilities.satisfies([3, 2, 1], [3, 1, 0]));
-    assert.isFalse(capabilities.satisfies([3, 2, 1], [3, 2]));
-    assert.isFalse(capabilities.satisfies([3, 2, 1], [3, 2]));
-    assert.isFalse(capabilities.satisfies([3, 2, 1], []));
+  test('versionAtLeast checks all required parts', () => {
+    assert.isTrue(capabilities.versionAtLeast([3, 2, 1], [3, 2, 1]));
+    assert.isTrue(capabilities.versionAtLeast([3, 2, 1], [3, 2, 1, 4]));
+    assert.isTrue(capabilities.versionAtLeast([3, 2, 1], [4, 1, 0]));
+    assert.isTrue(capabilities.versionAtLeast([3, 2, 0], [3, 2]));
+    assert.isFalse(capabilities.versionAtLeast([3, 2, 1], [2, 2, 1]));
+    assert.isFalse(capabilities.versionAtLeast([3, 2, 1], [3, 1, 1]));
+    assert.isFalse(capabilities.versionAtLeast([3, 2, 1], [3, 1, 0]));
+    assert.isFalse(capabilities.versionAtLeast([3, 2, 1], [3, 2]));
+    assert.isFalse(capabilities.versionAtLeast([3, 2, 1], [3, 2]));
+    assert.isFalse(capabilities.versionAtLeast([3, 2, 1], []));
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,6 +38,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
+"@types/ua-parser-js@^0.7.30":
+  version "0.7.30"
+  resolved "https://registry.yarnpkg.com/@types/ua-parser-js/-/ua-parser-js-0.7.30.tgz#9096e5552ff02f8d018a17efac69b4dc75083f8b"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -1416,6 +1420,10 @@ type-is@~1.6.14:
 typescript@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"
+
+ua-parser-js@^0.7.12:
+  version "0.7.12"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
 uid-number@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
A more complicated version of the ES2015 sniffer in Polyserve.

The idea is to use these capabilities as annotations on builds. E.g. to decide what build to serve, we take an ordered list of builds, and choose the first one for which all tagged capability requirements are satisfied.

Knows about ES2015 and HTTP/2 Push. Later we can add e.g. Custom Elements as a capability here, and use that to choose the Polyfill serverside.