### PR TITLE
Add an extra safeguard against directory traversal attacks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Relative push manifest paths are now interpreted as relative to the location of the push manifest file itself. Previously they were always interpreted as relative to the server root.
+- Extra safeguard against directory traversal attacks.
 
 ## [0.5.0] 2017-05-22
 - Add `serviceworker` to browser capability detection.

--- a/src/test/prpl_test.ts
+++ b/src/test/prpl_test.ts
@@ -95,6 +95,21 @@ suite('prpl server', function() {
         const {code} = await get('/foo.png');
         assert.equal(code, 404);
       });
+
+      test('forbids traversal outside root', async () => {
+        const {code, data} = await get('/../secrets');
+        assert.equal(code, 403);
+        assert.equal(data, 'Forbidden');
+      });
+
+      test('forbids traversal outside root with matching prefix', async () => {
+        // Edge case where the resolved request path naively matches the root
+        // directory by prefix even though it's actually a sibling, not a child
+        // ("/static-secrets" begins with "/static").
+        const {code, data} = await get('/../static-secrets');
+        assert.equal(code, 403);
+        assert.equal(data, 'Forbidden');
+      });
     });
 
     suite('with high capability user agent', () => {


### PR DESCRIPTION
The send library already ensures we don't serve files outside our root directory, but it doesn't hurt to check ourselves too. This also prevents a subtle way to probe if a file exists, even if you couldn't read it.