### PR TITLE
Add support for the Cache-Control header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Push manifest keys are now regular expression patterns instead of exact paths.
+- The `Cache-Control` header is now set to 1 minute by default (except for the entrypoint). Added the `cacheControl` config property and `--cache-control` flag to override.
 
 ## [0.9.0] 2017-08-23
 - Add `--bot-proxy` flag to proxy requests from bots through [Rendertron](https://github.com/GoogleChrome/rendertron).

--- a/README.md
+++ b/README.md
@@ -144,6 +144,25 @@ prpl-server trusts [`X-Forwarded-Proto`](https://developer.mozilla.org/en-US/doc
 
 You should always use `--https-redirect` in production, unless your reverse proxy already performs HTTPS redirection.
 
+## Caching
+
+By default, prpl-server sets the [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) header to `max-age=60` (1 minute), except for the entrypoint which gets `max-age=0`. [`ETag`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) headers are also sent, so resources that have not changed on the server can be re-validated efficiently.
+
+To change this default for non-entrypoint resources, set the `cacheControl` property in your configuration file, or the `--cache-control` command-line flag, to the desired `Cache-Control` header value. You may want to set `--cache-control=no-cache` during development.
+
+For more advanced caching behavior, use prpl-server as [a library](#as-a-library) and register a middleware that sets the `Cache-Control` header before prpl-server is invoked. If prpl-server sees that the `Cache-Control` header has already been set, it will not modify it. For example, to set year-long caching for images:
+
+```js
+app.get('/images/*', (req, res, next) => {
+  res.setHeader('Cache-Control', 'public, max-age=31536000');
+  next();
+});
+
+app.get('/*', prpl.makeHandler('.', config))
+```
+
+Choosing the right cache headers for your application can be complex. See [*Caching best practices & max-age gotchas*](https://jakearchibald.com/2016/caching-best-practices/) for one starting point.
+
 ## Rendering for Bots
 
 Many bots don't execute JavaScript when processing your application. This can cause your application to not render correctly when crawled by some search engines, social networks, and link rendering bots.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,6 +73,13 @@ const argDefs = [
     description: 'Proxy requests from bots/crawlers to this URL. See ' +
         'https://github.com/GoogleChrome/rendertron for more details.',
   },
+  {
+    name: 'cache-control',
+    type: String,
+    description:
+        'The Cache-Control header to send for all requests except the ' +
+        'entrypoint (default from config file or "max-age=60").',
+  },
 ];
 
 export function run(argv: string[]) {
@@ -117,12 +124,15 @@ export function run(argv: string[]) {
       console.warn('WARNING: No config found.');
     }
   }
-  let config;
+  let config: prpl.Config = {};
   if (args.config) {
     console.info(`Loading config from "${args.config}".`);
-    config =
-        JSON.parse(fs.readFileSync(args.config, 'utf8')) as prpl.ProjectConfig;
+    config = JSON.parse(fs.readFileSync(args.config, 'utf8')) as prpl.Config;
   }
+
+  if (args['cache-control']) {
+    config.cacheControl = args['cache-control'];
+  };
 
   const app = express();
 

--- a/src/test/prpl_test.ts
+++ b/src/test/prpl_test.ts
@@ -178,6 +178,20 @@ suite('prpl server', function() {
         const {headers} = await get('/foo/bar?custom-cache', chrome);
         assert.equal(headers['cache-control'], 'custom-cache');
       });
+
+      test('sends etag response header', async () => {
+        const {headers} = await get('/es2015/fragment.html', chrome);
+        assert.isNotEmpty(headers['etag']);
+      });
+
+      test('respects etag request header', async () => {
+        const {headers} = await get('/es2015/fragment.html', chrome);
+        const {code, data} = await get('/es2015/fragment.html', chrome, {
+          'If-None-Match': headers['etag'],
+        });
+        assert.equal(code, 304);
+        assert.equal(data, '');
+      });
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1310,9 +1310,9 @@ remove-trailing-separator@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz#69b062d978727ad14dc6b56ba4ab772fd8d70511"
 
-rendertron-middleware@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/rendertron-middleware/-/rendertron-middleware-0.1.0.tgz#9f20bffc1e2806b1f5ee08775abc0ae85f74f583"
+rendertron-middleware@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/rendertron-middleware/-/rendertron-middleware-0.1.2.tgz#e14f186d282c1dad7498893adc75a59abd59e02e"
   dependencies:
     request "^2.81.0"
 


### PR DESCRIPTION
The Cache-Control header is now set to `max-age=60` (1 minute) by default, except for the entrypoint which gets `max-age=0`. The `cacheControl` config file property and `--cache-control` flag can override this. If the Cache-Control header was already set (e.g. by an earlier middleware), it will not be modified.

Related to #41