### PR TITLE
Add a error function to be able to render a custom error page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [Unreleased]
+- Add `error` option to be able to serve custom error pages, like a 404 Not Found error page.
 
 ## [0.11.0] 2017-10-23
 - Add `unregisterMissingServiceWorkers` option (default true) which serves a tiny self-unregistering service worker for would-be 404 service worker requests, to prevent clients from getting stuck with invalid service workers indefinitely.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "command-line-usage": "^4.0.0",
     "compression": "^1.6.2",
     "express": "^4.15.2",
+    "http-errors": "^1.6.2",
     "rendertron-middleware": "^0.1.1",
     "send": "^0.15.2",
     "valid-url": "^1.0.9"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@types/compression": "^0.0.33",
     "@types/express": "^4.0.35",
+    "@types/http-errors": "^1.6.1",
     "@types/node": "^7.0.18",
     "@types/send": "^0.14.2",
     "@types/valid-url": "^1.0.2",

--- a/src/test/prpl_test.ts
+++ b/src/test/prpl_test.ts
@@ -304,8 +304,7 @@ suite('prpl server', function() {
             browserCapabilities: ['es2015' as capabilities.BrowserCapability],
           },
         ],
-        error: (req: http.IncomingMessage, res: http.ServerResponse) =>
-            (err: httpErrors.HttpError) => {
+        error: (req: http.IncomingMessage, res: http.ServerResponse, err: httpErrors.HttpError) => {
               res.statusCode = err.status || 500
               const customErrorPages = [403, 404, 500];
               const hasCustomErrorPage =

--- a/src/test/prpl_test.ts
+++ b/src/test/prpl_test.ts
@@ -293,4 +293,28 @@ suite('prpl server', function() {
           headers['link'], '</fragment.html>; rel=preload; as=document');
     });
   });
+
+  suite('configured with an error function', () => {
+    suiteSetup(async () => {
+      await startServer(path.join('src', 'test', 'static', 'standalone'), {
+        error: (req: any, res: any) => (err: any) => {
+          res.statusCode = err.status || 500
+
+          if(res.statusCode === 404) {
+            const url = req.url;
+            res.end(`Custom 404 error page for ${url}`);
+          } else {
+            res.end(err.message)
+          }
+        }
+      });
+    });
+
+    test('should return a 404 for a Not Found file', async () => {
+      const url = '/fragment/error.html';
+      const {code, data} = await get(url);
+      assert.equal(code, 404);
+      assert.include(data, `Custom 404 error page for ${url}`);
+    });
+  });
 });

--- a/src/test/prpl_test.ts
+++ b/src/test/prpl_test.ts
@@ -15,6 +15,7 @@
 import * as capabilities from 'browser-capabilities';
 import {assert} from 'chai';
 import * as http from 'http';
+import * as httpErrors from 'http-errors';
 import * as path from 'path';
 
 import * as prpl from '../prpl';
@@ -296,25 +297,58 @@ suite('prpl server', function() {
 
   suite('configured with an error function', () => {
     suiteSetup(async () => {
-      await startServer(path.join('src', 'test', 'static', 'standalone'), {
-        error: (req: any, res: any) => (err: any) => {
-          res.statusCode = err.status || 500
+      await startServer(path.join('src', 'test', 'static'), {
+        builds: [
+          {
+            name: 'es2015',
+            browserCapabilities: ['es2015' as capabilities.BrowserCapability],
+          },
+        ],
+        error: (req: http.IncomingMessage, res: http.ServerResponse) =>
+            (err: httpErrors.HttpError) => {
+              res.statusCode = err.status || 500
+              const customErrorPages = [403, 404, 500];
+              const hasCustomErrorPage =
+                  customErrorPages.includes(res.statusCode)
 
-          if(res.statusCode === 404) {
-            const url = req.url;
-            res.end(`Custom 404 error page for ${url}`);
-          } else {
-            res.end(err.message)
-          }
-        }
+              if (hasCustomErrorPage) {
+                res.end(`Custom ${res.statusCode} error page for ${req.url}`);
+              }
+              else {
+                res.end(err.message)
+              }
+            }
       });
     });
 
-    test('should return a 404 for a Not Found file', async () => {
-      const url = '/fragment/error.html';
-      const {code, data} = await get(url);
-      assert.equal(code, 404);
-      assert.include(data, `Custom 404 error page for ${url}`);
-    });
+    test(
+        'should render a custom 403 error page for directory traversal attack',
+        async () => {
+          const status = 403;
+          const url = '/../secrets';
+          const {code, data} = await get(url);
+          assert.equal(code, status);
+          assert.equal(data, `Custom ${status} error page for ${url}`);
+        });
+
+    test(
+        'should return a custom 404 error page for a Not Found file',
+        async () => {
+          const status = 404;
+          const url = '/fragment/error.html';
+          const {code, data} = await get(url);
+          assert.equal(code, status);
+          assert.include(data, `Custom ${status} error page for ${url}`);
+        });
+
+    test(
+        'should render a custom 500 error page to unsupported browsers',
+        async () => {
+          const status = 500;
+          const url = '/';
+          const {code, data} = await get(url);
+          assert.equal(code, status);
+          assert.equal(data, `Custom ${status} error page for ${url}`);
+        });
   });
 });


### PR DESCRIPTION
Hi,

Thanks for your module, it's really nice to be able to serve different builds to navigators!

For my website, I wanted to be able to serve a custom error page for _Not Found_ ressources, instead of the generic **Not Found** text. I tried to add a middleware function after my last route (/* -
 prpl.makeHandler), but my middleware was not called as I would have liked.

So, I dug into your source code and I added an error listener to the send stream.

I'm not sure my changes are the best way to serve this specific needs, but it's working.

Feel free to accept or to decline my pull request. :)

Have a nice day!