### PR TITLE
Optionally forward errors to the next Express error-handling middleware.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [Unreleased]
-- Add `error` option to be able to serve custom error pages, like a 404 Not Found error page.
+- Add `forwardErrors` option to pass 404s and other HTTP errors down to the next Express error-handling middleware.
 
 ## [0.11.0] 2017-10-23
 - Add `unregisterMissingServiceWorkers` option (default true) which serves a tiny self-unregistering service worker for would-be 404 service worker requests, to prevent clients from getting stuck with invalid service workers indefinitely.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ By default, prpl-server sets the [`Cache-Control`](https://developer.mozilla.org
 
 To change this default for non-entrypoint resources, set the `cacheControl` property in your configuration file, or the `--cache-control` command-line flag, to the desired `Cache-Control` header value. You may want to set `--cache-control=no-cache` during development.
 
-For more advanced caching behavior, use prpl-server as [a library](#as-a-library) and register a middleware that sets the `Cache-Control` header before prpl-server is invoked. If prpl-server sees that the `Cache-Control` header has already been set, it will not modify it. For example, to set year-long caching for images:
+For more advanced caching behavior, [use prpl-server as a library](#as-a-library) with Express and register a middleware that sets the `Cache-Control` header before registering the prpl-server middleware. If prpl-server sees that the `Cache-Control` header has already been set, it will not modify it. For example, to set year-long caching for images:
 
 ```js
 app.get('/images/*', (req, res, next) => {
@@ -171,6 +171,25 @@ app.get('/*', prpl.makeHandler('.', config))
 ```
 
 Choosing the right cache headers for your application can be complex. See [*Caching best practices & max-age gotchas*](https://jakearchibald.com/2016/caching-best-practices/) for one starting point.
+
+## HTTP Errors
+
+By default, if a `404 Not Found` or other HTTP server error occurs, prpl-server will serve a minimal `text/plain` response. To serve custom errors, [use prpl-server as a library](#as-a-library) with Express, set `forwardErrors: true` in your configuration object, and register an [error-handling middleware](http://expressjs.com/en/guide/error-handling.html) after registering the prpl-server handler:
+
+```js
+app.get('/*', prpl.makeHandler('.', {
+  builds: [ ... ],
+  forwardErrors: true
+}));
+
+app.use((err, req, res, next) => {
+  if (err.status === 404) {
+    res.status(404).sendFile('my-custom-404.html', {root: rootDir});
+  } else {
+    next();
+  }
+});
+```
 
 ## Rendering for Bots
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/http-errors": "^1.6.1",
     "@types/node": "^7.0.18",
     "@types/send": "^0.14.2",
+    "@types/statuses": "^1.3.0",
     "@types/valid-url": "^1.0.2",
     "ansi-escape-sequences": "^3.0.0",
     "browser-capabilities": "^0.2.1",
@@ -44,6 +45,7 @@
     "http-errors": "^1.6.2",
     "rendertron-middleware": "^0.1.1",
     "send": "^0.15.2",
+    "statuses": "^1.4.0",
     "valid-url": "^1.0.9"
   }
 }

--- a/src/prpl.ts
+++ b/src/prpl.ts
@@ -202,8 +202,6 @@ function writePlainTextError(
     response: http.ServerResponse, error: httpErrors.HttpError) {
   response.statusCode = error.status;
   response.setHeader('Content-Type', 'text/plain');
-  response.setHeader(
-      'Content-Length', Buffer.byteLength(error.message).toString());
   response.end(error.message);
 }
 

--- a/src/test/prpl_test.ts
+++ b/src/test/prpl_test.ts
@@ -29,7 +29,7 @@ suite('prpl server', function() {
   let host: string;
   let port: number;
 
-  const startServer = (root: string, config?: prpl.Config): Promise<void> => {
+  function startServer(root: string, config?: prpl.Config): Promise<void> {
     const handler = prpl.makeHandler(root, config);
     server = http.createServer(
         (request: http.IncomingMessage, response: http.ServerResponse) => {
@@ -49,14 +49,14 @@ suite('prpl server', function() {
         resolve();
       });
     });
-  };
+  }
 
-  const get =
-      (path: string, ua?: string, headers?: {[key: string]: string}): Promise<{
-        code: number | undefined,
-        data: string,
-        headers: {[key: string]: string}
-      }> => {
+  type GetResponse = {
+    code: number|undefined; data: string; headers: {[key: string]: string};
+  }
+
+  function get(path: string, ua?: string, headers?: {[key: string]: string}):
+      Promise<GetResponse> {
         return new Promise((resolve) => {
           const getHeaders = Object.assign({'user-agent': ua || ''}, headers);
           http.get({host, port, path, headers: getHeaders}, (response) => {
@@ -67,7 +67,15 @@ suite('prpl server', function() {
             response.on('end', () => resolve({code, data, headers}));
           });
         });
-      };
+      }
+
+  function checkPlainTextError(
+      expectCode: number, expectData: string, res: GetResponse) {
+    assert.equal(res.code, expectCode);
+    assert.equal(res.data, expectData);
+    assert.equal(res.headers['content-type'], 'text/plain');
+    assert.equal(res.headers['content-length'], String(expectData.length));
+  }
 
   suite('configured with multiple builds', () => {
     suiteSetup(async () => {
@@ -108,23 +116,18 @@ suite('prpl server', function() {
       });
 
       test('serves a 404 for missing file with extension', async () => {
-        const {code} = await get('/foo.png');
-        assert.equal(code, 404);
+        checkPlainTextError(404, 'Not Found', await get('/foo.png'));
       });
 
       test('forbids traversal outside root', async () => {
-        const {code, data} = await get('/../secrets');
-        assert.equal(code, 403);
-        assert.equal(data, 'Forbidden');
+        checkPlainTextError(403, 'Forbidden', await get('/../secrets'));
       });
 
       test('forbids traversal outside root with matching prefix', async () => {
         // Edge case where the resolved request path naively matches the root
         // directory by prefix even though it's actually a sibling, not a child
         // ("/static-secrets" begins with "/static").
-        const {code, data} = await get('/../static-secrets');
-        assert.equal(code, 403);
-        assert.equal(data, 'Forbidden');
+        checkPlainTextError(403, 'Forbidden', await get('/../static-secrets'));
       });
     });
 
@@ -148,8 +151,7 @@ suite('prpl server', function() {
       });
 
       test('serves a 404 for missing file with extension', async () => {
-        const {code} = await get('/foo.png', chrome);
-        assert.equal(code, 404);
+        checkPlainTextError(404, 'Not Found', await get('/foo.png'));
       });
 
       test('sets push headers for fragment', async () => {
@@ -239,9 +241,8 @@ suite('prpl server', function() {
     });
 
     test('serves 500 error to unsupported browser', async () => {
-      const {code, data} = await get('/');
-      assert.equal(code, 500);
-      assert.include(data, 'not supported');
+      checkPlainTextError(
+          500, 'This browser is not supported.', await get('/'));
     });
   });
 
@@ -316,6 +317,7 @@ suite('prpl server', function() {
            response: any,
            _next: express.NextFunction) => {
             response.statusCode = error.status;
+            response.setHeader('Content-Type', 'text/plain');
             response.end(`custom ${error.status}: ${error.message}`);
           });
 
@@ -331,21 +333,18 @@ suite('prpl server', function() {
     });
 
     test('forwards error for 404 not found', async () => {
-      const {code, data} = await get('/fragment/error.html');
-      assert.equal(code, 404);
-      assert.equal(data, 'custom 404: Not Found');
+      checkPlainTextError(
+          404, 'custom 404: Not Found', await get('/fragment/error.html'));
     });
 
     test('forwards error for directory traversal 403', async () => {
-      const {code, data} = await get('/../secrets');
-      assert.equal(code, 403);
-      assert.equal(data, 'custom 403: Forbidden');
+      checkPlainTextError(
+          403, 'custom 403: Forbidden', await get('/../secrets'));
     });
 
     test('forwards error for unsupported browser 500', async () => {
-      const {code, data} = await get('/');
-      assert.equal(code, 500);
-      assert.equal(data, 'custom 500: This browser is not supported.');
+      checkPlainTextError(
+          500, 'custom 500: This browser is not supported.', await get('/'));
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,10 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/http-errors@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-1.6.1.tgz#367744a6c04b833383f497f647cc3690b0cd4055"
+
 "@types/mime@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.1.tgz#2cf42972d0931c1060c7d5fa6627fce6bd876f2f"
@@ -61,6 +65,10 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
+
+"@types/statuses@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/statuses/-/statuses-1.3.0.tgz#991dce04cedf5f4fc4f66e4fdb9ec4ae1b1dfe29"
 
 "@types/ua-parser-js@^0.7.31":
   version "0.7.31"
@@ -798,7 +806,7 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-http-errors@1.6.2, http-errors@~1.6.2:
+http-errors@1.6.2, http-errors@^1.6.2, http-errors@~1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
   dependencies:
@@ -1535,6 +1543,10 @@ statsd-client@0.2.1:
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
+
+statuses@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This updates the previous approach that would invoke a custom error handler directly. This new approach is a bit more idiomatic for Express servers.