### PR TITLE
Prepare 1.0.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+
+## [1.0.0] 2017-10-30
 - Add `forwardErrors` option to pass 404s and other HTTP errors down to the next Express error-handling middleware.
 - Recommend `npm` instead of `yarn` and switch to `npm` lock file.
 - Check file existence asynchronously so the event loop is not blocked.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "build": "rm -Rf lib/ && tsc",
     "build:watch": "tsc --watch",
     "format": "find src -name '*.ts' | xargs clang-format --style=file -i",
+    "prepack": "npm run build",
+    "prepublishOnly": "npm run test",
     "test": "npm run build && mocha",
     "test:watch": "watchy -w src -- npm run test"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prpl-server",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "description": "A Node implementation of the PRPL pattern for serving Progressive Web Apps",
   "repository": "git+https://github.com/Polymer/prpl-server-node.git",
   "main": "lib/prpl.js",


### PR DESCRIPTION
Also add `prepack` and `prepublishOnly` scripts. Build before packing, so that the tar file we create contains compiled JS. Test before publishing, to make sure everything is ok!