### PR TITLE
Add preload as=fetch type

### DIFF
--- a/src/push.ts
+++ b/src/push.ts
@@ -127,6 +127,7 @@ const requestDestinations = new Set([
   'audio',
   'document',
   'embed',
+  'fetch',
   'font',
   'image',
   'manifest',

--- a/src/test/push_test.ts
+++ b/src/test/push_test.ts
@@ -19,6 +19,7 @@ suite('PushManifest', function() {
   test('validates types', () => {
     assert.doesNotThrow(() => {
       new push.PushManifest({'/a.html': {'/b.html': {type: 'document'}}});
+      new push.PushManifest({'/a.html': {'/api': {type: 'fetch'}}});
       new push.PushManifest({'/a.js': {'/b.js': {type: 'script'}}});
     });
     assert.throws(() => {


### PR DESCRIPTION
`as=fetch` is valid for preload according to https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content